### PR TITLE
Add custom advancements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>com.github.Trigary</groupId>
+      <artifactId>AdvancementCreator</artifactId>
+      <version>v2.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
@@ -43,6 +48,10 @@
     <repository>
       <id>dmulloy2-repo</id>
       <url>https://repo.dmulloy2.net/nexus/repository/public/</url>
+    </repository>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
     </repository>
     <repository>
       <id>spigot-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <filtering>true</filtering>
         <directory>src/main/resources</directory>
         <includes>
+          <include>config.yml</include>
           <include>plugin.yml</include>
         </includes>
       </resource>

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -1,5 +1,7 @@
 package com.hackclub.hccore;
 
+import java.util.ArrayList;
+import java.util.List;
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.ProtocolManager;
@@ -80,15 +82,16 @@ public class HCCorePlugin extends JavaPlugin {
     }
 
     private void registerAdvancements() {
-        AdvancementFactory factory = new AdvancementFactory(this, true, true);
+        AdvancementFactory factory = new AdvancementFactory(this, false, false);
 
+        // Create root advancement
         ItemObject hackClubBanner = new ItemObject().setItem(Material.RED_BANNER).setNbt(
                 "{BlockEntityTag:{Patterns:[{Color:0,Pattern:\"rs\"},{Color:14,Pattern:\"hh\"},{Color:0,Pattern:\"ls\"},{Color:0,Pattern:\"ms\"},{Color:14,Pattern:\"bo\"}]}}");
         Advancement root = new Advancement(new NamespacedKey(this, "root"), hackClubBanner,
                 new TextComponent("Hack Club"), new TextComponent("Beep boop beep beep boop"))
                         .makeRoot("block/coal_block", true).setFrame(Advancement.Frame.TASK);
-        root.activate(true);
 
+        // Create regular advancements
         Advancement allMusicDiscs = factory.getAllItems("all_music_discs", root, "Musicophile",
                 "Collect every single music disc", Material.JUKEBOX, Material.MUSIC_DISC_11,
                 Material.MUSIC_DISC_13, Material.MUSIC_DISC_BLOCKS, Material.MUSIC_DISC_CAT,
@@ -111,5 +114,27 @@ public class HCCorePlugin extends JavaPlugin {
                 .setFrame(Advancement.Frame.CHALLENGE);
         Advancement mineDiamondOre = factory.getImpossible("mine_diamond_ore", root,
                 "Look Ma, Diamonds!", "Find your first diamond while mining", Material.DIAMOND_ORE);
+
+        // Activate all the advancements
+        List<Advancement> advancements = new ArrayList<Advancement>() {
+            private static final long serialVersionUID = 0L;
+
+            {
+                add(root);
+                add(allMusicDiscs);
+                add(connectToNetherHub);
+                add(contribute);
+                add(killDragonInsane);
+                add(killElderGuardian);
+                add(killWitherInsane);
+                add(mineDiamondOre);
+            }
+        };
+        for (Advancement advancement : advancements) {
+            advancement.activate(false);
+        }
+
+        // Reload the data cache after all advancements have been added
+        this.getServer().reloadData();
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -100,7 +100,9 @@ public class HCCorePlugin extends JavaPlugin {
                 Material.MUSIC_DISC_WAIT, Material.MUSIC_DISC_WARD)
                 .setFrame(Advancement.Frame.CHALLENGE);
 
-        Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
+        Advancement findBug = factory.getImpossible("find_bug", root, "Bug Squasher",
+                "Find and report a bug", Material.IRON_BOOTS);
+        Advancement contribute = factory.getImpossible("contribute", findBug, "pairsOfHands++",
                 "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
 
         Advancement mineDiamondOre = factory.getImpossible("mine_diamond_ore", root,
@@ -128,6 +130,7 @@ public class HCCorePlugin extends JavaPlugin {
             {
                 add(root);
                 add(allMusicDiscs);
+                add(findBug);
                 add(contribute);
                 add(mineDiamondOre);
                 add(connectToNetherHub);

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -99,26 +99,27 @@ public class HCCorePlugin extends JavaPlugin {
                 Material.MUSIC_DISC_MELLOHI, Material.MUSIC_DISC_STAL, Material.MUSIC_DISC_STRAD,
                 Material.MUSIC_DISC_WAIT, Material.MUSIC_DISC_WARD)
                 .setFrame(Advancement.Frame.CHALLENGE);
-        Advancement connectToNetherHub = factory
-                .getImpossible("connect_to_nether_hub", root, "Linked Up",
-                        "Connect your base to the Nether hub", Material.POWERED_RAIL)
-                .setFrame(Advancement.Frame.GOAL);
+
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
                 "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
-        Advancement killDragonInsane = factory
-                .getCountedImpossible("kill_dragon_insane", root, "Dragon Master",
-                        "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
-                .setFrame(Advancement.Frame.CHALLENGE);
-        Advancement killElderGuardian = factory
-                .getKill("kill_elder_guardian", root, "The Deep End", "Defeat an Elder Guardian",
-                        Material.PRISMARINE_SHARD, EntityType.ELDER_GUARDIAN)
-                .setFrame(Advancement.Frame.GOAL);
-        Advancement killWitherInsane = factory
-                .getCountedImpossible("kill_wither_insane", root, "Are You Insane?!",
-                        "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)
-                .setFrame(Advancement.Frame.CHALLENGE);
+
         Advancement mineDiamondOre = factory.getImpossible("mine_diamond_ore", root,
                 "Look Ma, Diamonds!", "Find your first diamond while mining", Material.DIAMOND_ORE);
+        Advancement connectToNetherHub = factory
+                .getImpossible("connect_to_nether_hub", mineDiamondOre, "Linked Up",
+                        "Connect your base to the Nether hub", Material.POWERED_RAIL)
+                .setFrame(Advancement.Frame.GOAL);
+        Advancement killDragonInsane = factory
+                .getCountedImpossible("kill_dragon_insane", connectToNetherHub, "Dragon Master",
+                        "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
+                .setFrame(Advancement.Frame.CHALLENGE).setHidden(false);
+        Advancement killWitherInsane = factory
+                .getCountedImpossible("kill_wither_insane", killDragonInsane, "Are You Insane?!",
+                        "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)
+                .setFrame(Advancement.Frame.CHALLENGE);
+        Advancement killElderGuardian = factory.getKill("kill_elder_guardian", mineDiamondOre,
+                "The Deep End", "Defeat an Elder Guardian", Material.PRISMARINE_SHARD,
+                EntityType.ELDER_GUARDIAN).setFrame(Advancement.Frame.GOAL);
 
         // Activate all the advancements
         List<Advancement> advancements = new ArrayList<Advancement>() {
@@ -127,12 +128,12 @@ public class HCCorePlugin extends JavaPlugin {
             {
                 add(root);
                 add(allMusicDiscs);
-                add(connectToNetherHub);
                 add(contribute);
-                add(killDragonInsane);
-                add(killElderGuardian);
-                add(killWitherInsane);
                 add(mineDiamondOre);
+                add(connectToNetherHub);
+                add(killDragonInsane);
+                add(killWitherInsane);
+                add(killElderGuardian);
             }
         };
         for (Advancement advancement : advancements) {

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -32,6 +32,9 @@ public class HCCorePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Create config
+        this.saveDefaultConfig();
+
         // Load managers
         this.dataManager = new DataManager(this);
         this.protocolManager = ProtocolLibrary.getProtocolManager();
@@ -107,5 +110,7 @@ public class HCCorePlugin extends JavaPlugin {
                 .getCountedImpossible("kill_wither_insane", root, "Are You Insane?!",
                         "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)
                 .setFrame(Advancement.Frame.CHALLENGE);
+        Advancement mineDiamondOre = factory.getImpossible("mine_diamond_ore", root,
+                "Look Ma, Diamonds!", "Find your first diamond while mining", Material.DIAMOND_ORE);
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -76,5 +76,7 @@ public class HCCorePlugin extends JavaPlugin {
         // NOTE: Ideally, the icon should be a red banner with an "h" on it
         Advancement root = factory.getRoot("root", "Hack Club", "Beep boop beep beep boop",
                 Material.RED_GLAZED_TERRACOTTA, "block/coal_block");
+        Advancement connectToNetherHub = factory.getImpossible("connect_to_nether_hub", root,
+                "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -18,6 +18,7 @@ import com.hackclub.hccore.listeners.PlayerListener;
 import com.hackclub.hccore.listeners.SleepListener;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import hu.trigary.advancementcreator.Advancement;
 import hu.trigary.advancementcreator.Advancement.Frame;
@@ -94,6 +95,8 @@ public class HCCorePlugin extends JavaPlugin {
                 .getCountedImpossible("kill_dragon_insane", root, "Dragon Master",
                         "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
                 .setFrame(Advancement.Frame.CHALLENGE);
+        Advancement killElderGuardian = factory.getKill("kill_elder_guardian", root, "The Deep End",
+                "Defeat an Elder Guardian", Material.PRISMARINE_SHARD, EntityType.ELDER_GUARDIAN);
         Advancement killWitherInsane = factory
                 .getCountedImpossible("kill_wither_insane", root, "Are You Insane?!",
                         "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -21,7 +21,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import hu.trigary.advancementcreator.Advancement;
-import hu.trigary.advancementcreator.Advancement.Frame;
 import hu.trigary.advancementcreator.AdvancementFactory;
 import hu.trigary.advancementcreator.shared.ItemObject;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -87,7 +86,7 @@ public class HCCorePlugin extends JavaPlugin {
                 "{BlockEntityTag:{Patterns:[{Color:0,Pattern:\"rs\"},{Color:14,Pattern:\"hh\"},{Color:0,Pattern:\"ls\"},{Color:0,Pattern:\"ms\"},{Color:14,Pattern:\"bo\"}]}}");
         Advancement root = new Advancement(new NamespacedKey(this, "root"), hackClubBanner,
                 new TextComponent("Hack Club"), new TextComponent("Beep boop beep beep boop"))
-                        .makeRoot("block/coal_block", true).setFrame(Frame.TASK);
+                        .makeRoot("block/coal_block", true).setFrame(Advancement.Frame.TASK);
         root.activate(true);
 
         Advancement allMusicDiscs = factory.getAllItems("all_music_discs", root, "Musicophile",

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -92,5 +92,9 @@ public class HCCorePlugin extends JavaPlugin {
                 .getCountedImpossible("kill_dragon_insane", root, "Are You Insane?",
                         "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
                 .setFrame(Advancement.Frame.CHALLENGE);
+        Advancement killWitherInsane = factory
+                .getCountedImpossible("kill_wither_insane", root, "Totally Dominated",
+                        "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)
+                .setFrame(Advancement.Frame.CHALLENGE);
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -78,5 +78,7 @@ public class HCCorePlugin extends JavaPlugin {
                 Material.RED_GLAZED_TERRACOTTA, "block/coal_block");
         Advancement connectToNetherHub = factory.getImpossible("connect_to_nether_hub", root,
                 "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
+        Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
+                "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -88,5 +88,9 @@ public class HCCorePlugin extends JavaPlugin {
                 "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
                 "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
+        Advancement killDragonInsane = factory
+                .getCountedImpossible("kill_dragon_insane", root, "Are You Insane?",
+                        "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
+                .setFrame(Advancement.Frame.CHALLENGE);
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -16,9 +16,13 @@ import com.hackclub.hccore.listeners.NameChangeListener;
 import com.hackclub.hccore.listeners.PlayerListener;
 import com.hackclub.hccore.listeners.SleepListener;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.java.JavaPlugin;
 import hu.trigary.advancementcreator.Advancement;
+import hu.trigary.advancementcreator.Advancement.Frame;
 import hu.trigary.advancementcreator.AdvancementFactory;
+import hu.trigary.advancementcreator.shared.ItemObject;
+import net.md_5.bungee.api.chat.TextComponent;
 
 public class HCCorePlugin extends JavaPlugin {
     private DataManager dataManager;
@@ -73,9 +77,13 @@ public class HCCorePlugin extends JavaPlugin {
     private void registerAdvancements() {
         AdvancementFactory factory = new AdvancementFactory(this, true, true);
 
-        // NOTE: Ideally, the icon should be a red banner with an "h" on it
-        Advancement root = factory.getRoot("root", "Hack Club", "Beep boop beep beep boop",
-                Material.RED_GLAZED_TERRACOTTA, "block/coal_block");
+        ItemObject hackClubBanner = new ItemObject().setItem(Material.RED_BANNER).setNbt(
+                "{BlockEntityTag:{Patterns:[{Color:0,Pattern:\"rs\"},{Color:14,Pattern:\"hh\"},{Color:0,Pattern:\"ls\"},{Color:0,Pattern:\"ms\"},{Color:14,Pattern:\"bo\"}]}}");
+        Advancement root = new Advancement(new NamespacedKey(this, "root"), hackClubBanner,
+                new TextComponent("Hack Club"), new TextComponent("Beep boop beep beep boop"))
+                        .makeRoot("block/coal_block", true).setFrame(Frame.TASK);
+        root.activate(true);
+
         Advancement connectToNetherHub = factory.getImpossible("connect_to_nether_hub", root,
                 "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -87,6 +87,12 @@ public class HCCorePlugin extends JavaPlugin {
                         .makeRoot("block/coal_block", true).setFrame(Frame.TASK);
         root.activate(true);
 
+        Advancement allMusicDiscs = factory.getAllItems("all_music_discs", root, "Musicophile",
+                "Collect every single music disc", Material.JUKEBOX, Material.MUSIC_DISC_11,
+                Material.MUSIC_DISC_13, Material.MUSIC_DISC_BLOCKS, Material.MUSIC_DISC_CAT,
+                Material.MUSIC_DISC_CHIRP, Material.MUSIC_DISC_FAR, Material.MUSIC_DISC_MALL,
+                Material.MUSIC_DISC_MELLOHI, Material.MUSIC_DISC_STAL, Material.MUSIC_DISC_STRAD,
+                Material.MUSIC_DISC_WAIT, Material.MUSIC_DISC_WARD);
         Advancement connectToNetherHub = factory.getImpossible("connect_to_nether_hub", root,
                 "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -11,6 +11,7 @@ import com.hackclub.hccore.commands.NickCommand;
 import com.hackclub.hccore.commands.ShrugCommand;
 import com.hackclub.hccore.commands.SpawnCommand;
 import com.hackclub.hccore.commands.StatsCommand;
+import com.hackclub.hccore.listeners.AdvancementListener;
 import com.hackclub.hccore.listeners.BeehiveInteractionListener;
 import com.hackclub.hccore.listeners.NameChangeListener;
 import com.hackclub.hccore.listeners.PlayerListener;
@@ -44,6 +45,7 @@ public class HCCorePlugin extends JavaPlugin {
         this.getCommand("stats").setExecutor(new StatsCommand(this));
 
         // Register event listeners
+        this.getServer().getPluginManager().registerEvents(new AdvancementListener(this), this);
         this.getServer().getPluginManager().registerEvents(new BeehiveInteractionListener(this),
                 this);
         this.getServer().getPluginManager().registerEvents(new PlayerListener(this), this);

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -15,7 +15,10 @@ import com.hackclub.hccore.listeners.BeehiveInteractionListener;
 import com.hackclub.hccore.listeners.NameChangeListener;
 import com.hackclub.hccore.listeners.PlayerListener;
 import com.hackclub.hccore.listeners.SleepListener;
+import org.bukkit.Material;
 import org.bukkit.plugin.java.JavaPlugin;
+import hu.trigary.advancementcreator.Advancement;
+import hu.trigary.advancementcreator.AdvancementFactory;
 
 public class HCCorePlugin extends JavaPlugin {
     private DataManager dataManager;
@@ -46,6 +49,9 @@ public class HCCorePlugin extends JavaPlugin {
         this.getProtocolManager().addPacketListener(new NameChangeListener(this,
                 ListenerPriority.NORMAL, PacketType.Play.Server.PLAYER_INFO));
 
+        // Register advancements
+        this.registerAdvancements();
+
         // Register all the players that were online before this plugin was enabled (example
         // scenario: plugin reload) to prevent null pointer errors.
         this.getDataManager().registerAll();
@@ -62,5 +68,13 @@ public class HCCorePlugin extends JavaPlugin {
 
     public ProtocolManager getProtocolManager() {
         return this.protocolManager;
+    }
+
+    private void registerAdvancements() {
+        AdvancementFactory factory = new AdvancementFactory(this, true, true);
+
+        // NOTE: Ideally, the icon should be a red banner with an "h" on it
+        Advancement root = factory.getRoot("root", "Hack Club", "Beep boop beep beep boop",
+                Material.RED_GLAZED_TERRACOTTA, "block/coal_block");
     }
 }

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -97,17 +97,22 @@ public class HCCorePlugin extends JavaPlugin {
                 Material.MUSIC_DISC_13, Material.MUSIC_DISC_BLOCKS, Material.MUSIC_DISC_CAT,
                 Material.MUSIC_DISC_CHIRP, Material.MUSIC_DISC_FAR, Material.MUSIC_DISC_MALL,
                 Material.MUSIC_DISC_MELLOHI, Material.MUSIC_DISC_STAL, Material.MUSIC_DISC_STRAD,
-                Material.MUSIC_DISC_WAIT, Material.MUSIC_DISC_WARD);
-        Advancement connectToNetherHub = factory.getImpossible("connect_to_nether_hub", root,
-                "Linked Up", "Connect your base to the Nether hub", Material.POWERED_RAIL);
+                Material.MUSIC_DISC_WAIT, Material.MUSIC_DISC_WARD)
+                .setFrame(Advancement.Frame.CHALLENGE);
+        Advancement connectToNetherHub = factory
+                .getImpossible("connect_to_nether_hub", root, "Linked Up",
+                        "Connect your base to the Nether hub", Material.POWERED_RAIL)
+                .setFrame(Advancement.Frame.GOAL);
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
                 "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
         Advancement killDragonInsane = factory
                 .getCountedImpossible("kill_dragon_insane", root, "Dragon Master",
                         "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
                 .setFrame(Advancement.Frame.CHALLENGE);
-        Advancement killElderGuardian = factory.getKill("kill_elder_guardian", root, "The Deep End",
-                "Defeat an Elder Guardian", Material.PRISMARINE_SHARD, EntityType.ELDER_GUARDIAN);
+        Advancement killElderGuardian = factory
+                .getKill("kill_elder_guardian", root, "The Deep End", "Defeat an Elder Guardian",
+                        Material.PRISMARINE_SHARD, EntityType.ELDER_GUARDIAN)
+                .setFrame(Advancement.Frame.GOAL);
         Advancement killWitherInsane = factory
                 .getCountedImpossible("kill_wither_insane", root, "Are You Insane?!",
                         "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -89,11 +89,11 @@ public class HCCorePlugin extends JavaPlugin {
         Advancement contribute = factory.getImpossible("contribute", root, "pairsOfHands++",
                 "Contribute to the server’s codebase on GitHub", Material.COMMAND_BLOCK);
         Advancement killDragonInsane = factory
-                .getCountedImpossible("kill_dragon_insane", root, "Are You Insane?",
+                .getCountedImpossible("kill_dragon_insane", root, "Dragon Master",
                         "Kill the Ender Dragon 10 times", Material.DRAGON_HEAD, 10)
                 .setFrame(Advancement.Frame.CHALLENGE);
         Advancement killWitherInsane = factory
-                .getCountedImpossible("kill_wither_insane", root, "Totally Dominated",
+                .getCountedImpossible("kill_wither_insane", root, "Are You Insane?!",
                         "Kill the Wither 20 times", Material.WITHER_SKELETON_SKULL, 20)
                 .setFrame(Advancement.Frame.CHALLENGE);
     }

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -66,6 +66,10 @@ public class AdvancementListener implements Listener {
             case ENDER_DRAGON: {
                 this.incrementAdvancementProgress(player,
                         new NamespacedKey(this.plugin, "kill_dragon_insane"));
+
+                // Give "The Next Generation" since it's not easy to get it after the egg
+                // is taken
+                this.grantAdvancement(player, NamespacedKey.minecraft("end/dragon_egg"));
                 break;
             }
             case WITHER: {

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -16,7 +16,7 @@ public class AdvancementListener implements Listener {
     }
 
     @EventHandler
-    public void onEntityDeath(EntityDeathEvent event) {
+    public void onEntityDeath(final EntityDeathEvent event) {
         // Ignore non-player killers
         if (!(event.getEntity().getKiller() instanceof Player)) {
             return;

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -42,9 +42,9 @@ public class AdvancementListener implements Listener {
 
         this.grantAdvancement(player, key);
         player.sendMessage(ChatColor.GREEN
-                + "Congrats, you’ve found your very first diamond! You are now eligible for the exclusive Hack Club Minecraft Sticker—head over to "
+                + "Congrats, you’ve found your very first diamond! You are now eligible for the exclusive (and limited edition!) Hack Club Minecraft stickers. Head over to "
                 + ChatColor.UNDERLINE + this.plugin.getConfig().getString("claim-stickers-url")
-                + ChatColor.RESET + ChatColor.GREEN + " to claim it!");
+                + ChatColor.RESET + ChatColor.GREEN + " to claim them!");
         player.sendMessage(ChatColor.GRAY + ChatColor.ITALIC.toString()
                 + "You will only see this message once.");
     }

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -1,11 +1,14 @@
 package com.hackclub.hccore.listeners;
 
 import com.hackclub.hccore.HCCorePlugin;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.advancement.AdvancementProgress;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 
 public class AdvancementListener implements Listener {
@@ -13,6 +16,37 @@ public class AdvancementListener implements Listener {
 
     public AdvancementListener(HCCorePlugin plugin) {
         this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onBlockBreak(final BlockBreakEvent event) {
+        // Check if it's a diamond ore
+        if (event.getBlock().getType() != Material.DIAMOND_ORE) {
+            return;
+        }
+
+        // The diamond ore wasn't found underground
+        final int MAX_Y_DIAMOND_ORE = 16;
+        if (event.getBlock().getY() > MAX_Y_DIAMOND_ORE) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        NamespacedKey key = new NamespacedKey(this.plugin, "mine_diamond_ore");
+        AdvancementProgress progress =
+                player.getAdvancementProgress(player.getServer().getAdvancement(key));
+        // Skip if player already has this advancement
+        if (progress.isDone()) {
+            return;
+        }
+
+        this.grantAdvancement(player, key);
+        player.sendMessage(ChatColor.GREEN
+                + "Congrats, you’ve found your very first diamond! You are now eligible for the exclusive Hack Club Minecraft Sticker—head over to "
+                + ChatColor.UNDERLINE + this.plugin.getConfig().getString("claim-stickers-url")
+                + ChatColor.RESET + ChatColor.GREEN + " to claim it!");
+        player.sendMessage(ChatColor.GRAY + ChatColor.ITALIC.toString()
+                + "You will only see this message once.");
     }
 
     @EventHandler

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -1,0 +1,52 @@
+package com.hackclub.hccore.listeners;
+
+import com.hackclub.hccore.HCCorePlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+public class AdvancementListener implements Listener {
+    private final HCCorePlugin plugin;
+
+    public AdvancementListener(HCCorePlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        // Ignore non-player killers
+        if (!(event.getEntity().getKiller() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getEntity().getKiller();
+        switch (event.getEntityType()) {
+            case ENDER_DRAGON: {
+                this.incrementAdvancementProgress(player,
+                        new NamespacedKey(this.plugin, "kill_dragon_insane"));
+                break;
+            }
+            case WITHER: {
+                this.incrementAdvancementProgress(player,
+                        new NamespacedKey(this.plugin, "kill_wither_insane"));
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    private void incrementAdvancementProgress(Player player, NamespacedKey key) {
+        AdvancementProgress progress =
+                player.getAdvancementProgress(player.getServer().getAdvancement(key));
+        if (progress.isDone()) {
+            return;
+        }
+
+        String nextCriteria = String.valueOf(progress.getAwardedCriteria().size());
+        progress.awardCriteria(nextCriteria);
+    }
+}

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -24,6 +24,11 @@ public class AdvancementListener implements Listener {
 
         Player player = (Player) event.getEntity().getKiller();
         switch (event.getEntityType()) {
+            case ELDER_GUARDIAN: {
+                this.grantAdvancement(player,
+                        new NamespacedKey(this.plugin, "kill_elder_guardian"));
+                break;
+            }
             case ENDER_DRAGON: {
                 this.incrementAdvancementProgress(player,
                         new NamespacedKey(this.plugin, "kill_dragon_insane"));
@@ -36,6 +41,18 @@ public class AdvancementListener implements Listener {
             }
             default:
                 break;
+        }
+    }
+
+    private void grantAdvancement(Player player, NamespacedKey key) {
+        AdvancementProgress progress =
+                player.getAdvancementProgress(player.getServer().getAdvancement(key));
+        if (progress.isDone()) {
+            return;
+        }
+
+        for (String criteria : progress.getRemainingCriteria()) {
+            progress.awardCriteria(criteria);
         }
     }
 

--- a/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/PlayerListener.java
@@ -80,7 +80,8 @@ public class PlayerListener implements Listener {
                 message = ChatColor.RED + ChatColor.BOLD.toString() + "You’ve been banned :(\n\n"
                         + ChatColor.RESET + ChatColor.WHITE
                         + "If you believe this was a mistake, please DM " + ChatColor.AQUA
-                        + "@Luke " + ChatColor.WHITE + "or " + ChatColor.AQUA + "@ifvictr " + ChatColor.WHITE + "on Slack.";
+                        + "@Luke " + ChatColor.WHITE + "or " + ChatColor.AQUA + "@ifvictr "
+                        + ChatColor.WHITE + "on Slack.";
                 break;
             case KICK_FULL:
                 message = ChatColor.RED + ChatColor.BOLD.toString() + "The server is full!\n\n"
@@ -90,9 +91,11 @@ public class PlayerListener implements Listener {
             case KICK_WHITELIST:
                 message = ChatColor.RED + ChatColor.BOLD.toString() + "You’re not whitelisted!\n\n"
                         + ChatColor.RESET + ChatColor.WHITE + "Join " + ChatColor.AQUA
-                        + "#minecraft " + ChatColor.WHITE + "on Slack and ping "
-                        + ChatColor.AQUA + "@ifvictr " + ChatColor.WHITE + "or " + ChatColor.AQUA
-                        + "@Luke " + ChatColor.WHITE + "to be added.";
+                        + "#minecraft " + ChatColor.WHITE + "on Slack and ping " + ChatColor.AQUA
+                        + "@ifvictr " + ChatColor.WHITE + "or " + ChatColor.AQUA + "@Luke "
+                        + ChatColor.WHITE + "to be added.";
+                break;
+            default:
                 break;
         }
         event.setKickMessage(message);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,2 @@
 # URL to request form to claim exclusive Hack Club stickers
-claim-stickers-url: ""
+claim-stickers-url: "https://example.com/claim-stickers"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,2 @@
+# URL to request form to claim exclusive Hack Club stickers
+claim-stickers-url: ""


### PR DESCRIPTION
Added advancements for:
- Root
- Linking your base up to the Nether hub
- Contributing to any server-related codebases on GitHub
- Killing ender dragon 10 times
- Killing wither 20 times
- Killing elder guardian (in place of exploring ocean monument)
- Collect all music disc
- Find first diamond ore while mining
- Find and report bugs

Other changes:
- Grant "The Next Generation" advancement to the player when they defeat the dragon

<img width="956" alt="Screen Shot 2020-02-19 at 15 20 47" src="https://user-images.githubusercontent.com/10110245/74885864-729fdd00-532b-11ea-8e38-dcea52d7bf3b.png">
