### PR TITLE
Use nicknames in advancement messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
 jdk: openjdk8
 install: true
-script: mvn clean package
+script:
+  - wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+  - java -jar BuildTools.jar --rev 1.15.2
+  - mvn clean package
 cache:
   directories:
     - "$HOME/.m2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: openjdk8
 install: true
 script:
   - wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-  - java -jar BuildTools.jar --rev 1.15.2
+  - java -jar BuildTools.jar --rev 1.15.2 > /dev/null
   - mvn clean package
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ script:
 cache:
   directories:
     - "$HOME/.m2"
+    - "$HOME/BuildData"
+    - "$HOME/Bukkit"
+    - "$HOME/CraftBukkit"
+    - "$HOME/Spigot"
+    - "$HOME/work"
 deploy:
   - provider: releases
     api_key:

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
     </dependency>
     <dependency>
       <groupId>org.spigotmc</groupId>
+      <artifactId>spigot</artifactId>
+      <version>1.15.2-R0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
       <version>1.15.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.15.1-R0.1-SNAPSHOT</version>
+      <version>1.15.2-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/hackclub/hccore/HCCorePlugin.java
+++ b/src/main/java/com/hackclub/hccore/HCCorePlugin.java
@@ -19,8 +19,10 @@ import com.hackclub.hccore.listeners.BeehiveInteractionListener;
 import com.hackclub.hccore.listeners.NameChangeListener;
 import com.hackclub.hccore.listeners.PlayerListener;
 import com.hackclub.hccore.listeners.SleepListener;
+import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import hu.trigary.advancementcreator.Advancement;
@@ -34,6 +36,11 @@ public class HCCorePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Disable default advancement announcements
+        for (World world : this.getServer().getWorlds()) {
+            world.setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);
+        }
+
         // Create config
         this.saveDefaultConfig();
 

--- a/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
+++ b/src/main/java/com/hackclub/hccore/listeners/AdvancementListener.java
@@ -4,13 +4,22 @@ import com.hackclub.hccore.HCCorePlugin;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
+import org.bukkit.advancement.Advancement;
 import org.bukkit.advancement.AdvancementProgress;
+import org.bukkit.craftbukkit.v1_15_R1.advancement.CraftAdvancement;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.player.PlayerAdvancementDoneEvent;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.server.v1_15_R1.AdvancementDisplay;
+import net.minecraft.server.v1_15_R1.AdvancementFrameType;
+import net.minecraft.server.v1_15_R1.IChatBaseComponent;
 
 public class AdvancementListener implements Listener {
     private final HCCorePlugin plugin;
@@ -80,9 +89,9 @@ public class AdvancementListener implements Listener {
     @EventHandler
     public void onPlayerAdvancementDone(final PlayerAdvancementDoneEvent event) {
         Player player = event.getPlayer();
+        Advancement advancement = event.getAdvancement();
 
-        if (event.getAdvancement().getKey()
-                .equals(new NamespacedKey(this.plugin, "mine_diamond_ore"))) {
+        if (advancement.getKey().equals(new NamespacedKey(this.plugin, "mine_diamond_ore"))) {
             player.sendMessage(ChatColor.GREEN
                     + "Congrats, you’ve found your very first diamond! You are now eligible for the exclusive (and limited edition!) Hack Club Minecraft stickers. Head over to "
                     + ChatColor.UNDERLINE + this.plugin.getConfig().getString("claim-stickers-url")
@@ -91,6 +100,62 @@ public class AdvancementListener implements Listener {
                     + "*This offer only applies to players who have never received the stickers before. If you have, please do not fill out the form again!");
             player.sendMessage(ChatColor.GRAY + ChatColor.ITALIC.toString()
                     + "You will only see this message once.");
+        }
+
+        try {
+            // NOTE: We interface with Minecraft's internal code here. It is unlikely, but possible
+            // for it to break in the case of a future upgrade.
+            net.minecraft.server.v1_15_R1.Advancement nmsAdvancement =
+                    ((CraftAdvancement) advancement).getHandle();
+            AdvancementDisplay display = nmsAdvancement.c();
+
+            // Ignore hidden advancements (i.e. recipes)
+            if (display == null) {
+                return;
+            }
+
+            boolean announceToChat = display.i();
+            if (!announceToChat) {
+                return;
+            }
+
+            // Get frame type-specific wording + formatting
+            IChatBaseComponent titleComponent = display.a();
+            IChatBaseComponent descriptionComponent = display.b();
+            AdvancementFrameType frameType = display.e();
+            Object[] args = null; // This is bad practice
+            switch (frameType.a()) {
+                case "task":
+                default:
+                    args = new Object[] {"made", "advancement", ChatColor.GREEN};
+                    break;
+                case "goal":
+                    args = new Object[] {"reached", "goal", ChatColor.GREEN};
+                    break;
+                case "challenge":
+                    args = new Object[] {"completed", "challenge", ChatColor.DARK_PURPLE};
+                    break;
+            }
+
+            // Announce custom advancement message
+            BaseComponent nameComponent =
+                    new TextComponent(ChatColor.stripColor(player.getDisplayName()));
+            nameComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                    new ComponentBuilder(player.getName()).create()));
+            BaseComponent advancementComponent = new TextComponent(titleComponent.getText());
+            advancementComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                    new ComponentBuilder().color(((ChatColor) args[2]).asBungee())
+                            .append(titleComponent.getText() + "\n")
+                            .append(descriptionComponent.getText()).create()));
+
+            BaseComponent[] message = new ComponentBuilder(nameComponent)
+                    .append(String.format(" has %s the %s %s[", args),
+                            ComponentBuilder.FormatRetention.NONE)
+                    .append(advancementComponent)
+                    .append("]", ComponentBuilder.FormatRetention.FORMATTING).create();
+            player.getServer().spigot().broadcast(message);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
Closes #1.

Changes:
- Use nickname instead of username in advancement messages
- Show player's username when hovering on the nickname in advancement messages