### PR TITLE
Add VS Code tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea/
 .settings/
-.vscode/
 target/
 .classpath
 .project

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build plugin",
+      "type": "shell",
+      "command": "mvn -B install",
+      "group": "build",
+      "presentation": {
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Copy built plugin to server",
+      "type": "shell",
+      "command": "cp",
+      "args": [
+        "${workspaceRoot}/target/HCCore.jar",
+        "$HOME/server/plugins"
+      ],
+      "group": "build",
+      "presentation": {
+        "group": "dev"
+      }
+    },
+    {
+      "label": "Install",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Build plugin",
+        "Copy built plugin to server"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Start server",
+      "type": "shell",
+      "command": "./start.sh",
+      "options": {
+        "cwd": "${env:HOME}/server/"
+      },
+      "presentation": {
+        "group": "dev"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Sharing my VS Code development setup. This task setup makes two assumptions:
1. Your Spigot server is located at `~/server`
2. You have [BileTools](https://www.spigotmc.org/resources/biletools-test-plugins-faster.54823/) installed so "Copy built plugin to server" triggers a hot-reload
3. Your server start script is at `~/server/start.sh`