### PR TITLE
Fix exploit in /nick command

### DIFF
--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -32,7 +32,7 @@ public class NickCommand implements CommandExecutor {
         String newNickname = String.join(" ", args);
         if (newNickname.equals("Saharsh")) {
             player.kickPlayer("Kicked for being Saharsh.");
-            this.plugin.getDataManager().getData(player).setNickname("Saharchary");
+            this.plugin.getDataManager().getData(player).setNickname("Saharchery");
             return true;
         }
 

--- a/src/main/java/com/hackclub/hccore/commands/NickCommand.java
+++ b/src/main/java/com/hackclub/hccore/commands/NickCommand.java
@@ -30,6 +30,12 @@ public class NickCommand implements CommandExecutor {
         }
 
         String newNickname = String.join(" ", args);
+        if (newNickname.equals("Saharsh")) {
+            player.kickPlayer("Kicked for being Saharsh.");
+            this.plugin.getDataManager().getData(player).setNickname("Saharchary");
+            return true;
+        }
+
         if (newNickname.length() > PlayerData.MAX_NICKNAME_LENGTH) {
             sender.sendMessage(ChatColor.RED + "Your nickname can’t be longer than "
                     + PlayerData.MAX_NICKNAME_LENGTH + " characters");


### PR DESCRIPTION
The nick command currently allows an exploit (CVE-1957-XKCD) that allows an arbitrary user to break the Code of Conduct (which shall be referred to as the CoC from here on out) to invoke the name of [redacted].
This commit kicks the player trying to do so as a warning and changes their nick to a SWF CoC approved version.